### PR TITLE
jwnb-jx-angular-io-quickstart to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,3 +13,6 @@ dependencies:
 - name: jwnb-jx-python-http
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: jwnb-jx-angular-io-quickstart
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1


### PR DESCRIPTION
Promote jwnb-jx-angular-io-quickstart to version 0.0.1